### PR TITLE
Fix bug in data loading

### DIFF
--- a/acsa/data_adapter/data_object.py
+++ b/acsa/data_adapter/data_object.py
@@ -1119,6 +1119,7 @@ class Semeval2016Task5RestSub1(Semeval2016Task5Sub1):
                         aspect_categories_temp[category].add(polarity)
                     for category, polarities in aspect_categories_temp.items():
                         if len(polarities) == 1:
+                            polarity = polarities.pop()
                             label.append((category, polarity))
                             distinct_categories.add(category)
                             distinct_polarities.add(polarity)


### PR DESCRIPTION
When an aspect has only one polarity, the current code incorrectly appends the variable polarity, which has the leftover value from the previous 'for' loop. It has to get the unique value from the 'polarities' variable.